### PR TITLE
Add trailing semicolon to prevent file concat issues

### DIFF
--- a/src/d3.tip.js
+++ b/src/d3.tip.js
@@ -268,4 +268,4 @@ d3.tip = function() {
   }
 
   return tip;
-}
+};


### PR DESCRIPTION
Depending on how you concat and minify your javascript files, the lack of a trailing semicolon in `d3.tip.js` can cause issues. This just adds the semicolon.

The already minified `ds.tip.min.js` does have a trailing semicolon, but I like to included the unminified files for development purposes, and then have my own build process concat and minify all my files together.

Basically, without the trailing semicolon, if you simply concat all your dependencies together, it can break things. Here's an example of what was happening without the trailing semicolon:

``` javascript
d3.tip = function() {
}
// Next File:
(function() {
}());
```

Or to put it more succinctly, without the semicolon, d3.tip's function ends up getting called with the next file's function passed in as a param:

``` javascript
d3.tip = function() {}(function() {}());
```
