### PR TITLE
Hide/Show tips with display: block/none

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ d3.tip = function() {
         coords
 
     nodel.html(content)
-      .style({ opacity: 1, 'pointer-events': 'all' })
+      .style({ opacity: 1, display:'block', 'pointer-events': 'all' })
 
     while(i--) nodel.classed(directions[i], false)
     coords = direction_callbacks.get(dir).apply(this)
@@ -48,7 +48,7 @@ d3.tip = function() {
   // Returns a tip
   tip.hide = function() {
     nodel = d3.select(node)
-    nodel.style({ opacity: 0, 'pointer-events': 'none' })
+    nodel.style({ opacity: 0, 'display':'none', 'pointer-events': 'none' })
     return tip
   }
 
@@ -209,6 +209,7 @@ d3.tip = function() {
     node.style({
       position: 'absolute',
       opacity: 0,
+      display:'none',
       pointerEvents: 'none',
       boxSizing: 'border-box'
     })


### PR DESCRIPTION
Using just opacity:0 to hide the tooltips prevented underlying DOM
elements from receiving hover/click events. Adding a display:block/none
to hide/show fixed the issue.
