### PR TITLE
After show a tooltip, it stays on top of the dom blocking other elements mouseover event

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ d3.tip = function() {
         coords
 
     nodel.html(content)
-      .style({ opacity: 1, 'pointer-events': 'all' })
+      .style({ opacity: 1, 'pointer-events': 'all', 'display':'block' })
 
     while(i--) nodel.classed(directions[i], false)
     coords = direction_callbacks.get(dir).apply(this)
@@ -48,7 +48,7 @@ d3.tip = function() {
   // Returns a tip
   tip.hide = function() {
     nodel = d3.select(node)
-    nodel.style({ opacity: 0, 'pointer-events': 'none' })
+    nodel.style({ opacity: 0, 'pointer-events': 'none', 'display':'none' })
     return tip
   }
 


### PR DESCRIPTION
When a tooltip after the tooltip is shown it stays on top of the other dom elements, so it blocks the mouse over event of the elements behind it.

When the tooltip is shown, now, it sets the display style to block and when the tootip is hidden it is set to hidden.
