### PR TITLE
Correctly detect `document.documentElement`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,8 +250,9 @@ d3.tip = function() {
         height     = tbbox.height,
         x          = tbbox.x,
         y          = tbbox.y,
-        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
-        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+        scrollEl   = document.documentElement? document.documentElement : document.body,
+        scrollTop  = scrollEl.scrollTop,
+        scrollLeft = scrollEl.scrollLeft
 
 
     point.x = x + scrollLeft


### PR DESCRIPTION
Before, if the `document.documentElement.scrollTop` or `document.documentElement.scrollTop` was `0`, the condition evaluated to false and the scroll value was fetched from `document.body` instead. This raised a warning in chrome. Now, we first find the available scroll element and then get its scroll value.
