### PR TITLE
Fixed `document.body` warning when getting scroll offset.

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,8 +250,8 @@ d3.tip = function() {
         height     = tbbox.height,
         x          = tbbox.x,
         y          = tbbox.y,
-        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
-        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+        scrollTop  = window.pageXOffset || document.documentElement.scrollLeft,
+        scrollLeft = window.pageYOffset || document.documentElement.scrollTop
 
 
     point.x = x + scrollLeft


### PR DESCRIPTION
Now using same code as the FB React framework to get unbounded scroll offset.
See Issue #41.
