### PR TITLE
make fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 components
 bower_components
 node_modules
-d3.tip.min.*
+d3-tip.min.*

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 UGLIFYJS = node_modules/uglify-js/bin/uglifyjs
 UGLIFYCSS = node_modules/uglifycss/uglifycss
 
-all: d3.tip.min.js d3.tip.min.css
+all: d3-tip.min.js d3-tip.min.css
 
-d3.tip.min.js: index.js uglifyjs
+d3-tip.min.js: index.js uglifyjs
 	$(UGLIFYJS) $< -c -m -o $@
 
-d3.tip.min.css: examples/example-styles.css uglifycss
+d3-tip.min.css: examples/example-styles.css uglifycss
 	$(UGLIFYCSS) $< > $@
 
 clean:
-	@rm -f d3.tip.min.*
+	@rm -f d3-tip.min.*
 
 uglifyjs: $(UGLIFYJS)
 $(UGLIFYJS):


### PR DESCRIPTION
I fixed the Makefile so that you can easily just clone the repository and run `make` to build the minified versions. This is related to #35 but stripped down so it only includes the `Makefile` changes and not a buncha other nonsense with renaming files and whatnot.

I'm doing this so that its easier to [put this on cdnjs](https://github.com/cdnjs/cdnjs/pull/2619). bower is pretty awesome for collecting resources for websites, but I personally tend to use CDNs as we move to production and think this would be useful. Speaking of cdnjs, I hope you're cool with the [package.json](https://github.com/deanmalmgren/cdnjs/commit/c318f19e38c74236ef48fdec2604c1cb7b188c4c) I put together for d3-tip on cdnjs. I didn't include your email out of respect for some reasonable amount of privacy...
