### PR TITLE
update documentation with an offset callback example

### DIFF
--- a/docs/positioning-tooltips.md
+++ b/docs/positioning-tooltips.md
@@ -31,3 +31,12 @@ enough in the desired direction so the extender doesn't overlap the target eleme
 ``` javascript
 tip.offset([10, -10])
 ```
+
+Callbacks are also supported for dynamic positioning.  The following example
+will center tip placement within the bounding box of the target element.
+
+``` javascript
+tip.offset(function() {
+  return [this.getBBox().height / 2, 0]
+})
+```


### PR DESCRIPTION
Hi, here is a small addition to the documentation with an example of passing a callback to `tip.offset()` for dynamically positioning the tip. This came in handy when adding tips to variously shaped polygons so I hope it will be useful to others as well.
