### PR TITLE
fix AMD

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@
     define(['d3'], factory)
   } else {
     // Browser global.
-    root.d3.tip = factory(root.d3)
+    factory(root.d3)
   }
 }(this, function (d3) {
 
   // Public - contructs a new tooltip
   //
   // Returns a tip
-  return function() {
+  d3.tip = function() {
     var direction = d3_tip_direction,
         offset    = d3_tip_offset,
         html      = d3_tip_html,
@@ -24,20 +24,20 @@
         svg       = null,
         point     = null,
         target    = null
-  
+
     function tip(vis) {
       svg = getSVGNode(vis)
       point = svg.createSVGPoint()
       document.body.appendChild(node)
     }
-  
+
     // Public - show the tooltip on the screen
     //
     // Returns a tip
     tip.show = function() {
       var args = Array.prototype.slice.call(arguments)
       if(args[args.length - 1] instanceof SVGElement) target = args.pop()
-  
+
       var content = html.apply(this, args),
           poffset = offset.apply(this, args),
           dir     = direction.apply(this, args),
@@ -46,20 +46,20 @@
           coords,
           scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
           scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
-  
+
       nodel.html(content)
         .style({ opacity: 1, 'pointer-events': 'all' })
-  
+
       while(i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
       nodel.classed(dir, true).style({
         top: (coords.top +  poffset[0]) + scrollTop + 'px',
         left: (coords.left + poffset[1]) + scrollLeft + 'px'
       })
-  
+
       return tip
     }
-  
+
     // Public - hide the tooltip
     //
     // Returns a tip
@@ -68,7 +68,7 @@
       nodel.style({ opacity: 0, 'pointer-events': 'none' })
       return tip
     }
-  
+
     // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
     //
     // n - name of the attribute
@@ -82,10 +82,10 @@
         var args =  Array.prototype.slice.call(arguments)
         d3.selection.prototype.attr.apply(d3.select(node), args)
       }
-  
+
       return tip
     }
-  
+
     // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
     //
     // n - name of the property
@@ -99,10 +99,10 @@
         var args =  Array.prototype.slice.call(arguments)
         d3.selection.prototype.style.apply(d3.select(node), args)
       }
-  
+
       return tip
     }
-  
+
     // Public: Set or get the direction of the tooltip
     //
     // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
@@ -112,10 +112,10 @@
     tip.direction = function(v) {
       if (!arguments.length) return direction
       direction = v == null ? v : d3.functor(v)
-  
+
       return tip
     }
-  
+
     // Public: Sets or gets the offset of the tip
     //
     // v - Array of [x, y] offset
@@ -124,10 +124,10 @@
     tip.offset = function(v) {
       if (!arguments.length) return offset
       offset = v == null ? v : d3.functor(v)
-  
+
       return tip
     }
-  
+
     // Public: sets or gets the html value of the tooltip
     //
     // v - String value of the tip
@@ -136,14 +136,14 @@
     tip.html = function(v) {
       if (!arguments.length) return html
       html = v == null ? v : d3.functor(v)
-  
+
       return tip
     }
-  
+
     function d3_tip_direction() { return 'n' }
     function d3_tip_offset() { return [0, 0] }
     function d3_tip_html() { return ' ' }
-  
+
     var direction_callbacks = d3.map({
       n:  direction_n,
       s:  direction_s,
@@ -154,9 +154,9 @@
       sw: direction_sw,
       se: direction_se
     }),
-  
+
     directions = direction_callbacks.keys()
-  
+
     function direction_n() {
       var bbox = getScreenBBox()
       return {
@@ -164,7 +164,7 @@
         left: bbox.n.x - node.offsetWidth / 2
       }
     }
-  
+
     function direction_s() {
       var bbox = getScreenBBox()
       return {
@@ -172,7 +172,7 @@
         left: bbox.s.x - node.offsetWidth / 2
       }
     }
-  
+
     function direction_e() {
       var bbox = getScreenBBox()
       return {
@@ -180,7 +180,7 @@
         left: bbox.e.x
       }
     }
-  
+
     function direction_w() {
       var bbox = getScreenBBox()
       return {
@@ -188,7 +188,7 @@
         left: bbox.w.x - node.offsetWidth
       }
     }
-  
+
     function direction_nw() {
       var bbox = getScreenBBox()
       return {
@@ -196,7 +196,7 @@
         left: bbox.nw.x - node.offsetWidth
       }
     }
-  
+
     function direction_ne() {
       var bbox = getScreenBBox()
       return {
@@ -204,7 +204,7 @@
         left: bbox.ne.x
       }
     }
-  
+
     function direction_sw() {
       var bbox = getScreenBBox()
       return {
@@ -212,7 +212,7 @@
         left: bbox.sw.x - node.offsetWidth
       }
     }
-  
+
     function direction_se() {
       var bbox = getScreenBBox()
       return {
@@ -220,7 +220,7 @@
         left: bbox.e.x
       }
     }
-  
+
     function initNode() {
       var node = d3.select(document.createElement('div'))
       node.style({
@@ -230,18 +230,18 @@
         'pointer-events': 'none',
         'box-sizing': 'border-box'
       })
-  
+
       return node.node()
     }
-  
+
     function getSVGNode(el) {
       el = el.node()
       if(el.tagName.toLowerCase() == 'svg')
         return el
-  
+
       return el.ownerSVGElement
     }
-  
+
     // Private - gets the screen coordinates of a shape
     //
     // Given a shape on the screen, will return an SVGPoint for the directions
@@ -264,7 +264,7 @@
           height     = tbbox.height,
           x          = tbbox.x,
           y          = tbbox.y
-  
+
       point.x = x
       point.y = y
       bbox.nw = point.matrixTransform(matrix)
@@ -283,11 +283,13 @@
       bbox.n = point.matrixTransform(matrix)
       point.y += height
       bbox.s = point.matrixTransform(matrix)
-  
+
       return bbox
     }
-  
+
     return tip
   };
+
+  return d3.tip;
 
 }));


### PR DESCRIPTION
When importing both `d3` and `d3.tip` using `Require.js`, `d3.tip` does not set the d3 object's tip method. This pull request fixes that.
