### PR TITLE
Adding npm packaging to support browserify.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-tip",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "index.js",
   "ignore": [
     "**/.*",

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module with d3 as a dependency.
     define(['d3'], factory)
+  } else if (typeof require === 'function' && module.exports) {
+    var d3 = require('d3')
+    module.exports = d3.tip = factory(d3)
   } else {
     // Browser global.
     root.d3.tip = factory(root.d3)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "d3-tip",
+  "version": "0.6.5",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Caged/d3-tip.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Caged/d3-tip/issues"
+  },
+  "homepage": "https://github.com/Caged/d3-tip"
+}


### PR DESCRIPTION
I'm using d3 with browserify and started using your package. Since I'm building my project with browserify I improved this package's compatibility.
You should publish this package to npm, if you prefer I'll do it myself.
