### PR TITLE
Fix screen bounding box detection in case the event target is foreignobject HTML content

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,8 +256,13 @@
     //
     // Returns an Object {n, s, e, w, nw, sw, ne, se}
     function getScreenBBox() {
-      var targetel   = target || d3.event.target,
-          bbox       = {},
+      var targetel   = target || d3.event.target;
+
+      while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
+          targetel = targetel.parentNode;
+      }
+
+      var bbox       = {},
           matrix     = targetel.getScreenCTM(),
           tbbox      = targetel.getBBox(),
           width      = tbbox.width,


### PR DESCRIPTION
Hello,

In case I attach tip.show on a svg node event, for example:

``` js
d3.selectAll(".node")
  .on('mouseover', function(n){
    tip.show(n);
  });
```

If this `.node` SVG element contains a foreignobject containing HTML, the `d3.event.target` is an HTMLDivElement and an error `Uncaught TypeError: undefined is not a function` because the method `getScreenCTM` does not exist in foreignobject children. 
This patch bubbles in the DOM until a valid SVG element that have the `getScreenCTM` method.
