### PR TITLE
fix IE incorrect tooltip positioning after scroll

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,9 @@
           nodel   = d3.select(node),
           i       = directions.length,
           coords,
-          scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
-          scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+          scrollEl   = document.documentElement? document.documentElement : document.body,
+          scrollTop  = scrollEl.scrollTop,
+          scrollLeft = scrollEl.scrollLeft
   
       nodel.html(content)
         .style({ opacity: 1, 'pointer-events': 'all' })


### PR DESCRIPTION
Issue #39 recurs in IE11 due to modifications introduced by pull request #52. A partial rollback to commit be99e94 can solve the issue: scroll element needs to be defined as `document.documentElement? document.documentElement : document.body`.
