### PR TITLE
Fixing AMD support. Before this fix when I used d3-tip in require.js it ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@
     define(['d3'], factory)
   } else {
     // Browser global.
-    root.d3.tip = factory(root.d3)
+    factory(root.d3)
   }
 }(this, function (d3) {
 
   // Public - contructs a new tooltip
   //
   // Returns a tip
-  return function() {
+  d3.tip = function() {
     var direction = d3_tip_direction,
         offset    = d3_tip_offset,
         html      = d3_tip_html,
@@ -289,5 +289,5 @@
 
     return tip
   };
-
+  return d3.tip;
 }));


### PR DESCRIPTION
alanhamlett submitted these changes before. Without them d3-tip is useless to me because it does not load within requirejs (d3.tip() shows up as undefined).

If d3-tip doesn't work for you then include this fork in your bower.json instead of the canonical repository. Replace d3-tip in bower.json with this:

"d3-tip": "https://github.com/hendrixski/d3-tip.git#0.6.5_bower_fix" 

To include d3-tip in require.js just add d3-tip into paths and into shim:
paths:{ "d3-tip":                "../bower_components/d3-tip/index"}
shim: { d3-tip: ["d3"]}
