### PR TITLE
Return gracefully when a node hasn't been found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@
 
     function tip(vis) {
       svg = getSVGNode(vis)
+      if (svg == null) return;
       point = svg.createSVGPoint()
       document.body.appendChild(node)
     }
@@ -242,6 +243,7 @@
 
     function getSVGNode(el) {
       el = el.node()
+      if (el == null) return
       if(el.tagName.toLowerCase() === 'svg')
         return el
 


### PR DESCRIPTION
When initializing my d3 graphics, including the d3-tip function, (getSVGNode) cannot find a proper node yet, and el.tagName generates an exception. Therefore I've added a simple check to see if the svg node isn't null.
Hope you will accept it...