### PR TITLE
Hide tooltip for null content

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@
           scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
           scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
 
+      // null content indicates no tooltip
+      if(content == null) return;
       nodel.html(content)
         .style({ opacity: 1, 'pointer-events': 'all' })
 


### PR DESCRIPTION
Sometimes one would like to hide the tooltip for some elements.  I think the most logical way to do this is to not show tooltips if the content is null.  This mimics d3's behavior of deleting html content when null is passed to [`selection.html()`](https://github.com/mbostock/d3/wiki/Selections#html).

An example of when this would be useful is the following code snippet, where you don't want to show tooltips for elements with no `contents`:

``` Javascript
tip.html(function(d){
  if(d.contents) {
    return d.contents.join("<br>");
  } else {
    return null;
  }
});
```
