### PR TITLE
added checks for null in tip and getSVGNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@
 
     function tip(vis) {
       svg = getSVGNode(vis)
+      if(!svg){
+        return;
+      }
       point = svg.createSVGPoint()
       document.body.appendChild(node)
     }
@@ -242,6 +245,9 @@
 
     function getSVGNode(el) {
       el = el.node()
+      if(!el){
+        return;
+      }
       if(el.tagName.toLowerCase() === 'svg')
         return el
 


### PR DESCRIPTION
I was using d3 in ember and for some reason, it throws an error when I do my binding the first time (perhaps because of empty data).   The error was happening because getSVGNode was breaking because el.node() returns null.  I added null checks and it all worked.

I was getting this error:
```
Cannot read property 'tagName' of null
```