### PR TITLE
Support explicit parent for d3-tip element

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,18 +30,18 @@
         svg       = null,
         point     = null,
         target    = null,
-        parent    = document.body
+        parent    = null
 
     function tip(vis) {
       svg = getSVGNode(vis)
       point = svg.createSVGPoint()
-      parent.appendChild(node)
     }
 
     // Public - show the tooltip on the screen
     //
     // Returns a tip
     tip.show = function() {
+      if(!parent) tip.parent(document.body);
       var args = Array.prototype.slice.call(arguments)
       if(args[args.length - 1] instanceof SVGElement) target = args.pop()
 
@@ -146,10 +146,22 @@
       return tip
     }
 
+    // Public: Sets or gets the parent of the tooltip element
+    //
+    // v - New parent for the tip
+    //
+    // Returns parent element or tip
     tip.parent = function(v) {
       if (!arguments.length) return parent
       parent = v || document.body
       parent.appendChild(node)
+
+      // Make sure offsetParent has a position so the tip can be
+      // based from it. Mainly a concern with <body>.
+      var offsetParent = d3.select(node.offsetParent)
+      if (offsetParent.style('position') === 'static') {
+        offsetParent.style('position', 'relative')
+      }
 
       return tip
     }

--- a/index.js
+++ b/index.js
@@ -29,12 +29,13 @@
         node      = initNode(),
         svg       = null,
         point     = null,
-        target    = null
+        target    = null,
+        parent    = document.body
 
     function tip(vis) {
       svg = getSVGNode(vis)
       point = svg.createSVGPoint()
-      document.body.appendChild(node)
+      parent.appendChild(node)
     }
 
     // Public - show the tooltip on the screen
@@ -50,8 +51,7 @@
           nodel   = d3.select(node),
           i       = directions.length,
           coords,
-          scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
-          scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+          parentCoords = node.offsetParent.getBoundingClientRect()
 
       nodel.html(content)
         .style({ opacity: 1, 'pointer-events': 'all' })
@@ -59,8 +59,8 @@
       while(i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
       nodel.classed(dir, true).style({
-        top: (coords.top +  poffset[0]) + scrollTop + 'px',
-        left: (coords.left + poffset[1]) + scrollLeft + 'px'
+        top: (coords.top + poffset[0]) - parentCoords.top + 'px',
+        left: (coords.left + poffset[1]) - parentCoords.left + 'px'
       })
 
       return tip
@@ -142,6 +142,14 @@
     tip.html = function(v) {
       if (!arguments.length) return html
       html = v == null ? v : d3.functor(v)
+
+      return tip
+    }
+
+    tip.parent = function(v) {
+      if (!arguments.length) return parent
+      parent = v || document.body
+      parent.appendChild(node)
 
       return tip
     }


### PR DESCRIPTION
Change positioning logic to match

This is to support positioning tips with the graph inside a fixed
position container so you can scroll the page while the tip is visible.

It also improves support for perma-visible tips in moving containers or
resizing windows.

Fixes #102
