### PR TITLE
0.6.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-tip",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "index.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-tip",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Tooltips for d3 svg visualizations",
   "author": "Justin Palmer <justin@labratrevenge.com> (http://labratrevenge.com/d3-tip)",
   "main": "index.js",


### PR DESCRIPTION
Bump a version (0.6.6 -> 0.6.7).

Changelog:
  * Update d3 version (3.4 -> 3.5.5)
  * Add tip.destroy() to remove the DOM element