### PR TITLE
properly require d3 for npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,7 @@
     define(['d3'], factory)
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS
-    module.exports = function(d3) {
-      d3.tip = factory(d3)
-      return d3.tip
-    }
+    module.exports = factory(require('d3'))
   } else {
     // Browser global.
     root.d3.tip = factory(root.d3)


### PR DESCRIPTION
bare `factory(d3)` is unresolved; using a require in here will do the right thing.