### PR TITLE
Set visibility property on hide/show.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@
           scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
 
       nodel.html(content)
-        .style({ opacity: 1, 'pointer-events': 'all' })
+        .style({ visibility: 'visible', opacity: 1, 'pointer-events': 'all' })
 
       while(i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
@@ -71,7 +71,7 @@
     // Returns a tip
     tip.hide = function() {
       var nodel = getNodeEl()
-      nodel.style({ opacity: 0, 'pointer-events': 'none' })
+      nodel.style({ visibility: 'hidden', opacity: 0, 'pointer-events': 'none' })
       return tip
     }
 


### PR DESCRIPTION
IE 10 and below don't support the CSS pointer-events property for non-SVG elements. Fixed #94.
