### PR TITLE
suppress hide if pointer over tooltip

### DIFF
--- a/docs/showing-and-hiding-tooltips.md
+++ b/docs/showing-and-hiding-tooltips.md
@@ -38,3 +38,5 @@ rect.on('mouseout', function(d) {
   tip.hide(d)
 })
 ```
+
+If the cursor is moved over the tooltip itself it will not be hidden.

--- a/index.js
+++ b/index.js
@@ -68,10 +68,22 @@
 
     // Public - hide the tooltip
     //
+    // Will not hide the tooltip if both of the following:
+    //   a) we can get a ref to the element under mouse pointer
+    //   b) that element is the tooltip
+    // 
     // Returns a tip
     tip.hide = function() {
       var nodel = getNodeEl()
-      nodel.style({ opacity: 0, 'pointer-events': 'none' })
+      var el = null
+      
+      if (document.elementFromPoint) {
+      	el = document.elementFromPoint(d3.event.clientX, d3.event.clientY);
+      }
+
+      if (el !== nodel[0][0]) {
+	      nodel.style({ opacity: 0, 'pointer-events': 'none' })
+	    }
       return tip
     }
 

--- a/index.js
+++ b/index.js
@@ -82,13 +82,13 @@
       }
 
       if (el !== nodel[0][0]) {
-	      nodel.style({ opacity: 0, 'pointer-events': 'none' })
-	    }
+        nodel.style({ opacity: 0, 'pointer-events': 'none' })
+      }
 
-	    // todo: The tooltip will remain showing until the user hovers over the
-	    // target svg element again and mouses out. This could be solved by adding
-	    // a mouseout handler to the tip itself when it is first created.
-	    
+      // todo: The tooltip will remain showing until the user hovers over the
+      // target svg element again and mouses out. This could be solved by adding
+      // a mouseout handler to the tip itself when it is first created.
+      
       return tip
     }
 

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@
     tip.hide = function() {
       var nodel = getNodeEl()
       var el = null
-      
+
       if (document.elementFromPoint) {
       	el = document.elementFromPoint(d3.event.clientX, d3.event.clientY);
       }
@@ -84,6 +84,11 @@
       if (el !== nodel[0][0]) {
 	      nodel.style({ opacity: 0, 'pointer-events': 'none' })
 	    }
+
+	    // todo: The tooltip will remain showing until the user hovers over the
+	    // target svg element again and mouses out. This could be solved by adding
+	    // a mouseout handler to the tip itself when it is first created.
+	    
       return tip
     }
 


### PR DESCRIPTION
It may be desirable in some cases to include UI elements inside a tooltip. A simple example is a link. This change keeps the tip from being hidden if the pointer is over the tip.

A side effect is that, if the user then mouses out of the tooltip, it will remain showing until mousing over either the original or a new element and then mousing out normally. I think a simple fix for that would be to attach a mouseout handler to the tip when it's first created, which simply calls tip.hide().
