### PR TITLE
added left:0 to node that tips get appended to

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,6 +243,7 @@
       node.style({
         position: 'absolute',
         top: 0,
+        left: 0,
         opacity: 0,
         'pointer-events': 'none',
         'box-sizing': 'border-box'


### PR DESCRIPTION
this fixes an issue where hidden tooltips were causing horizontal overflow and thus unneeded horizontal scrollbars when appended to body.
#135 could also be a solution where you specify the element to append to and add overflow stylings to ensure the scrollbar doesn't appear when not actually needed.
