### PR TITLE
Tooltip overflows body

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@
 
     function tip(vis) {
       svg = getSVGNode(vis)
+      if (!svg) { return; }
       point = svg.createSVGPoint()
       document.body.appendChild(node)
     }
@@ -253,6 +254,7 @@
 
     function getSVGNode(el) {
       el = el.node()
+      if (!el) { return; }
       if(el.tagName.toLowerCase() === 'svg')
         return el
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@
       svg = getSVGNode(vis)
       if (!svg) { return; }
       point = svg.createSVGPoint()
+      if(!node) { return; }
       document.body.appendChild(node)
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-tip",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Tooltips for d3 svg visualizations",
   "author": "Justin Palmer <justin@labratrevenge.com> (http://labratrevenge.com/d3-tip)",
   "main": "index.js",


### PR DESCRIPTION
Added logic to prevent the tooltip from overflowing the body and added a span to use as an arrow pointer instead of an after element