### PR TITLE
Remove duplicate author line from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "d3",
     "tooltip"
   ],
-  "author": "Justin Palmer",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Caged/d3-tip/issues"


### PR DESCRIPTION
Line 5 is
```
"author": "Justin Palmer <justin@labratrevenge.com> (http://labratrevenge.com/d3-tip)",
```

so this one could be removed.