### PR TITLE
d3 micro libraries

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "docs"
   ],
   "dependencies": {
-    "d3": "^4.2"
+    "d3-collection": "^1.0.1",
+    "d3-selection": "^1.0.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,19 +8,24 @@
 ;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module with d3 as a dependency.
-    define(['d3'], factory)
+    define([
+      'd3-collection',
+      'd3-selection'
+    ], factory)
   } else if (typeof module === 'object' && module.exports) {
     /* eslint-disable global-require */
     // CommonJS
-    var d3 = require('d3')
-    module.exports = factory(d3)
+    var d3Collection = require('d3-collection'),
+        d3Selection = require('d3-selection')
+    module.exports = factory(d3Collection, d3Selection)
     /* eslint-enable global-require */
   } else {
     // Browser global.
+    var d3 = root.d3
     // eslint-disable-next-line no-param-reassign
-    root.d3.tip = factory(root.d3)
+    root.d3.tip = factory(d3, d3)
   }
-}(this, function(d3) {
+}(this, function(d3Collection, d3Selection) {
   // Public - contructs a new tooltip
   //
   // Returns a tip
@@ -93,7 +98,7 @@
       }
 
       var args =  Array.prototype.slice.call(arguments)
-      d3.selection.prototype.attr.apply(getNodeEl(), args)
+      d3Selection.selection.prototype.attr.apply(getNodeEl(), args)
       return tip
     }
 
@@ -111,7 +116,7 @@
       }
 
       var args = Array.prototype.slice.call(arguments)
-      d3.selection.prototype.style.apply(getNodeEl(), args)
+      d3Selection.selection.prototype.style.apply(getNodeEl(), args)
       return tip
     }
 
@@ -167,7 +172,7 @@
     function d3TipOffset() { return [0, 0] }
     function d3TipHTML() { return ' ' }
 
-    var directionCallbacks = d3.map({
+    var directionCallbacks = d3Collection.map({
           n:  directionNorth,
           s:  directionSouth,
           e:  directionEast,
@@ -244,7 +249,7 @@
     }
 
     function initNode() {
-      var div = d3.select(document.createElement('div'))
+      var div = d3Selection.select(document.createElement('div'))
       div
         .style('position', 'absolute')
         .style('top', 0)
@@ -268,7 +273,7 @@
         // re-add node to DOM
         document.body.appendChild(node)
       }
-      return d3.select(node)
+      return d3Selection.select(node)
     }
 
     // Private - gets the screen coordinates of a shape
@@ -285,7 +290,7 @@
     //
     // Returns an Object {n, s, e, w, nw, sw, ne, se}
     function getScreenBBox() {
-      var targetel   = target || d3.event.target
+      var targetel   = target || d3Selection.event.target
 
       while (targetel.getScreenCTM == null && targetel.parentNode == null) {
         targetel = targetel.parentNode

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "d3": "^4.2"
+    "d3-collection": "^1.0.1",
+    "d3-selection": "^1.0.2"
   },
   "devDependencies": {
     "eslint": "^3.3.1",


### PR DESCRIPTION
- Removed the `d3.tip` mutation in the CommonJS loader, `d3.tip` should now only show up for the vanilla loader
- Replaced the `d3` dependency with the `d3-selection` and `d3-collection` micro libraries

~~Unfortunately, while I tried to keep the changes minimal, I haven't had a chance to properly test this code to make sure it works right.~~ I've tested this fork out on my current d3-tip setup and it works well so far! 😄  I'm using Webpack, which is making use of the AMD implementation in d3-tip, so the CommonJS and browser loaders might need some testing?