### PR TITLE
Use require to load d3 in CommonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,8 @@
     define(['d3'], factory)
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS
-    module.exports = function(d3) {
-      d3.tip = factory(d3)
-      return d3.tip
-    }
+    var d3 = require('d3')
+    module.exports = factory(d3)
   } else {
     // Browser global.
     root.d3.tip = factory(root.d3)

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/Caged/d3-tip/issues"
   },
-  "homepage": "https://github.com/Caged/d3-tip"
+  "homepage": "https://github.com/Caged/d3-tip",
+  "dependencies": {
+    "d3": "^4.2"
+  }
 }


### PR DESCRIPTION
Sorry about being late to the party about this, but it occurred to me recently that it's very odd for d3-tip to be exporting a function that accepts d3, instead of just using `require('d3')` to load d3 and then export the output from the factory directly.

(Based on #160 because it's already related to dependency management, and rebased into #161 since that one was already using `require`)