### PR TITLE
Enable linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Markdown
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -48,13 +48,6 @@
 
     # Additional rules
     func-names: 0
-    no-unused-vars:
-      - 1
-      -
-        vars: all
-        args: all
-        varsIgnorePattern: ^_
-        argsIgnorePattern: ^_
 
     # Disabled for IE8 support
     comma-dangle: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,67 @@
+---
+  root: true
+  extends:
+    - airbnb-base/legacy
+  env:
+    browser: true
+    node: true
+    amd: true
+  rules:
+    # Customised whitespace
+    max-len:
+      - 1
+      - 80
+      - 2
+      -
+        ignoreUrls: true
+        ignoreComments: false
+    indent:
+      - 1
+      - 2
+      -
+        SwitchCase: 1
+        VariableDeclarator:
+          var: 2
+          let: 2
+          const: 3
+        outerIIFEBody: 1
+    no-multi-spaces:
+      - 1
+      -
+        exceptions:
+          VariableDeclarator: true
+    key-spacing:
+      - 1
+      -
+        align: value
+    space-before-function-paren:
+      - 1
+      - never
+
+    # Customised to existing code's style
+    semi:
+      - 1
+      - never
+
+    # You don't need this one when you know your operators
+    no-mixed-operators: 0
+
+    # Additional rules
+    func-names: 0
+    no-unused-vars:
+      - 1
+      -
+        vars: all
+        args: all
+        varsIgnorePattern: ^_
+        argsIgnorePattern: ^_
+
+    # Disabled for IE8 support
+    comma-dangle: 0
+
+    # Airbnb rules that were disabled due to too many conflicts
+    # with the existing code style
+    vars-on-top: 0
+    one-var: 0
+    camelcase: 0
+    no-use-before-define: 0

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -63,5 +63,4 @@
     # with the existing code style
     vars-on-top: 0
     one-var: 0
-    camelcase: 0
     no-use-before-define: 0

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
+## Customize the test machine
+machine:
+  # Version of Node to use
+  node:
+    version: 6.1.0
+
 ## Customize dependencies
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+## Customize dependencies
+dependencies:
+  override:
+    - npm prune
+    - npm install
+
+## Customize test command
+test:
+  override:
+    - npm run -s circle:lint

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@
   //
   // Returns a tip
   return function() {
-    var direction = d3_tip_direction,
-        offset    = d3_tip_offset,
-        html      = d3_tip_html,
+    var direction = d3TipDirection,
+        offset    = d3TipOffset,
+        html      = d3TipHTML,
         node      = initNode(),
         svg       = null,
         point     = null,
@@ -60,7 +60,7 @@
         .style('opacity', 1).style('pointer-events', 'all')
 
       while (i--) nodel.classed(directions[i], false)
-      coords = direction_callbacks.get(dir).apply(this)
+      coords = directionCallbacks.get(dir).apply(this)
       nodel.classed(dir, true)
         .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
         .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
@@ -159,23 +159,23 @@
       return tip
     }
 
-    function d3_tip_direction() { return 'n' }
-    function d3_tip_offset() { return [0, 0] }
-    function d3_tip_html() { return ' ' }
+    function d3TipDirection() { return 'n' }
+    function d3TipOffset() { return [0, 0] }
+    function d3TipHTML() { return ' ' }
 
-    var direction_callbacks = d3.map({
-          n:  direction_n,
-          s:  direction_s,
-          e:  direction_e,
-          w:  direction_w,
-          nw: direction_nw,
-          ne: direction_ne,
-          sw: direction_sw,
-          se: direction_se
+    var directionCallbacks = d3.map({
+          n:  directionNorth,
+          s:  directionSouth,
+          e:  directionEast,
+          w:  directionWest,
+          nw: directionNorthWest,
+          ne: directionNorthEast,
+          sw: directionSouthWest,
+          se: directionSouthEast
         }),
-        directions = direction_callbacks.keys()
+        directions = directionCallbacks.keys()
 
-    function direction_n() {
+    function directionNorth() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.n.y - node.offsetHeight,
@@ -183,7 +183,7 @@
       }
     }
 
-    function direction_s() {
+    function directionSouth() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.s.y,
@@ -191,7 +191,7 @@
       }
     }
 
-    function direction_e() {
+    function directionEast() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.e.y - node.offsetHeight / 2,
@@ -199,7 +199,7 @@
       }
     }
 
-    function direction_w() {
+    function directionWest() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.w.y - node.offsetHeight / 2,
@@ -207,7 +207,7 @@
       }
     }
 
-    function direction_nw() {
+    function directionNorthWest() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.nw.y - node.offsetHeight,
@@ -215,7 +215,7 @@
       }
     }
 
-    function direction_ne() {
+    function directionNorthEast() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.ne.y - node.offsetHeight,
@@ -223,7 +223,7 @@
       }
     }
 
-    function direction_sw() {
+    function directionSouthWest() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.sw.y,
@@ -231,7 +231,7 @@
       }
     }
 
-    function direction_se() {
+    function directionSouthEast() {
       var bbox = getScreenBBox()
       return {
         top:  bbox.se.y,

--- a/index.js
+++ b/index.js
@@ -3,20 +3,22 @@
 //
 // Tooltips for d3.js SVG visualizations
 
-(function (root, factory) {
+(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module with d3 as a dependency.
     define(['d3'], factory)
   } else if (typeof module === 'object' && module.exports) {
+    /* eslint-disable global-require */
     // CommonJS
     var d3 = require('d3')
     module.exports = factory(d3)
+    /* eslint-enable global-require */
   } else {
     // Browser global.
+    // eslint-disable-next-line no-param-reassign
     root.d3.tip = factory(root.d3)
   }
-}(this, function (d3) {
-
+}(this, function(d3) {
   // Public - contructs a new tooltip
   //
   // Returns a tip
@@ -41,7 +43,7 @@
     // Returns a tip
     tip.show = function() {
       var args = Array.prototype.slice.call(arguments)
-      if(args[args.length - 1] instanceof SVGElement) target = args.pop()
+      if (args[args.length - 1] instanceof SVGElement) target = args.pop()
 
       var content = html.apply(this, args),
           poffset = offset.apply(this, args),
@@ -49,20 +51,22 @@
           nodel   = getNodeEl(),
           i       = directions.length,
           coords,
-          scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
-          scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+          scrollTop  = document.documentElement.scrollTop ||
+            document.body.scrollTop,
+          scrollLeft = document.documentElement.scrollLeft ||
+            document.body.scrollLeft
 
       nodel.html(content)
         .style('opacity', 1).style('pointer-events', 'all')
 
-      while(i--) nodel.classed(directions[i], false)
+      while (i--) nodel.classed(directions[i], false)
       coords = direction_callbacks.get(dir).apply(this)
       nodel.classed(dir, true)
-      	.style('top', (coords.top +  poffset[0]) + scrollTop + 'px')
-      	.style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+        .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
+        .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
 
-      return tip;
-    };
+      return tip
+    }
 
     // Public - hide the tooltip
     //
@@ -73,37 +77,37 @@
       return tip
     }
 
-    // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
+    // Public: Proxy attr calls to the d3 tip container.
+    // Sets or gets attribute value.
     //
     // n - name of the attribute
     // v - value of the attribute
     //
     // Returns tip or attribute value
-    tip.attr = function(n, v) {
+    tip.attr = function(n, _v) {
       if (arguments.length < 2 && typeof n === 'string') {
         return getNodeEl().attr(n)
-      } else {
-        var args =  Array.prototype.slice.call(arguments)
-        d3.selection.prototype.attr.apply(getNodeEl(), args)
       }
 
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.attr.apply(getNodeEl(), args)
       return tip
     }
 
-    // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
+    // Public: Proxy style calls to the d3 tip container.
+    // Sets or gets a style value.
     //
     // n - name of the property
     // v - value of the property
     //
     // Returns tip or style property value
-    tip.style = function(n, v) {
+    tip.style = function(n, _v) {
       if (arguments.length < 2 && typeof n === 'string') {
         return getNodeEl().style(n)
-      } else {
-        var args = Array.prototype.slice.call(arguments)
-        d3.selection.prototype.style.apply(getNodeEl(), args)
       }
 
+      var args = Array.prototype.slice.call(arguments)
+      d3.selection.prototype.style.apply(getNodeEl(), args)
       return tip
     }
 
@@ -148,11 +152,11 @@
     //
     // Returns a tip
     tip.destroy = function() {
-      if(node) {
-        getNodeEl().remove();
-        node = null;
+      if (node) {
+        getNodeEl().remove()
+        node = null
       }
-      return tip;
+      return tip
     }
 
     function d3_tip_direction() { return 'n' }
@@ -160,17 +164,16 @@
     function d3_tip_html() { return ' ' }
 
     var direction_callbacks = d3.map({
-      n:  direction_n,
-      s:  direction_s,
-      e:  direction_e,
-      w:  direction_w,
-      nw: direction_nw,
-      ne: direction_ne,
-      sw: direction_sw,
-      se: direction_se
-    }),
-
-    directions = direction_callbacks.keys()
+          n:  direction_n,
+          s:  direction_s,
+          e:  direction_e,
+          w:  direction_w,
+          nw: direction_nw,
+          ne: direction_ne,
+          sw: direction_sw,
+          se: direction_se
+        }),
+        directions = direction_callbacks.keys()
 
     function direction_n() {
       var bbox = getScreenBBox()
@@ -237,11 +240,15 @@
     }
 
     function initNode() {
-      var node = d3.select(document.createElement('div'));
-      node.style('position', 'absolute').style('top', 0).style('opacity', 0)
-      	.style('pointer-events', 'none').style('box-sizing', 'border-box')
+      var div = d3.select(document.createElement('div'))
+      div
+        .style('position', 'absolute')
+        .style('top', 0)
+        .style('opacity', 0)
+        .style('pointer-events', 'none')
+        .style('box-sizing', 'border-box')
 
-      return node.node()
+      return div.node()
     }
 
     function getSVGNode(element) {
@@ -252,19 +259,19 @@
     }
 
     function getNodeEl() {
-      if(node === null) {
-        node = initNode();
+      if (node == null) {
+        node = initNode()
         // re-add node to DOM
-        document.body.appendChild(node);
-      };
-      return d3.select(node);
+        document.body.appendChild(node)
+      }
+      return d3.select(node)
     }
 
     // Private - gets the screen coordinates of a shape
     //
     // Given a shape on the screen, will return an SVGPoint for the directions
-    // n(north), s(south), e(east), w(west), ne(northeast), se(southeast), nw(northwest),
-    // sw(southwest).
+    // n(north), s(south), e(east), w(west), ne(northeast), se(southeast),
+    // nw(northwest), sw(southwest).
     //
     //    +-+-+
     //    |   |
@@ -274,10 +281,10 @@
     //
     // Returns an Object {n, s, e, w, nw, sw, ne, se}
     function getScreenBBox() {
-      var targetel   = target || d3.event.target;
+      var targetel   = target || d3.event.target
 
-      while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
-          targetel = targetel.parentNode;
+      while (targetel.getScreenCTM == null && targetel.parentNode == null) {
+        targetel = targetel.parentNode
       }
 
       var bbox       = {},
@@ -298,7 +305,7 @@
       point.x -= width
       bbox.sw = point.matrixTransform(matrix)
       point.y -= height / 2
-      bbox.w  = point.matrixTransform(matrix)
+      bbox.w = point.matrixTransform(matrix)
       point.x += width
       bbox.e = point.matrixTransform(matrix)
       point.x -= width / 2
@@ -309,15 +316,15 @@
 
       return bbox
     }
-    
+
     // Private - replace D3JS 3.X d3.functor() function
     function functor(v) {
-    	return typeof v === "function" ? v : function() {
+      return typeof v === 'function' ? v : function() {
         return v
-    	}
+      }
     }
 
     return tip
-  };
-
+  }
+// eslint-disable-next-line semi
 }));

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
-// d3.tip
-// Copyright (c) 2013 Justin Palmer
-//
-// Tooltips for d3.js SVG visualizations
-
-(function(root, factory) {
+/**
+ * d3.tip
+ * Copyright (c) 2013 Justin Palmer
+ *
+ * Tooltips for d3.js SVG visualizations
+ */
+// eslint-disable-next-line no-extra-semi
+;(function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module with d3 as a dependency.
     define(['d3'], factory)
@@ -84,7 +86,8 @@
     // v - value of the attribute
     //
     // Returns tip or attribute value
-    tip.attr = function(n, _v) {
+    // eslint-disable-next-line no-unused-vars
+    tip.attr = function(n, v) {
       if (arguments.length < 2 && typeof n === 'string') {
         return getNodeEl().attr(n)
       }
@@ -101,7 +104,8 @@
     // v - value of the property
     //
     // Returns tip or style property value
-    tip.style = function(n, _v) {
+    // eslint-disable-next-line no-unused-vars
+    tip.style = function(n, v) {
       if (arguments.length < 2 && typeof n === 'string') {
         return getNodeEl().style(n)
       }

--- a/package.json
+++ b/package.json
@@ -2,30 +2,30 @@
   "name": "d3-tip",
   "version": "0.7.1",
   "description": "Tooltips for d3 svg visualizations",
+  "keywords": [
+    "d3",
+    "tooltip"
+  ],
+  "homepage": "https://github.com/Caged/d3-tip",
+  "bugs": {
+    "url": "https://github.com/Caged/d3-tip/issues"
+  },
+  "license": "MIT",
   "author": "Justin Palmer <justin@labratrevenge.com> (http://labratrevenge.com/d3-tip)",
   "main": "index.js",
   "directories": {
     "doc": "docs",
     "example": "examples"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "eslint .",
-    "circle:lint": "npm run -s lint -- --max-warnings 0 -f junit -o $CIRCLE_TEST_REPORTS/eslint/junit.xml"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Caged/d3-tip"
   },
-  "keywords": [
-    "d3",
-    "tooltip"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Caged/d3-tip/issues"
+  "scripts": {
+    "circle:lint": "npm run -s lint -- --max-warnings 0 -f junit -o $CIRCLE_TEST_REPORTS/eslint/junit.xml",
+    "lint": "eslint .",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "homepage": "https://github.com/Caged/d3-tip",
   "dependencies": {
     "d3": "^4.2"
   },
@@ -33,5 +33,11 @@
     "eslint": "^3.3.1",
     "eslint-config-airbnb-base": "^5.0.3",
     "eslint-plugin-import": "^1.14.0"
+  },
+  "engines": {
+    "node": ">=4.2.6"
+  },
+  "greenkeeper": {
+    "branchPrefix": "greenkeeper/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "example": "examples"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint .",
+    "circle:lint": "npm run -s lint -- --max-warnings 0 -f junit -o $CIRCLE_TEST_REPORTS/eslint/junit.xml"
   },
   "repository": {
     "type": "git",
@@ -26,5 +28,10 @@
   "homepage": "https://github.com/Caged/d3-tip",
   "dependencies": {
     "d3": "^4.2"
+  },
+  "devDependencies": {
+    "eslint": "^3.3.1",
+    "eslint-config-airbnb-base": "^5.0.3",
+    "eslint-plugin-import": "^1.14.0"
   }
 }


### PR DESCRIPTION
@Caged I was thinking it would be good to make use of [ESLint](http://eslint.org/) to keep the code style consistent.

Instead of building up a bunch of rules from scratch, I started with [Airbnb's presets](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base) and then added some further tweaks to match the existing code style that I could see.

Are there any formatting rules you'd like added, or any you'd like changed/removed?
These were some notable rules I had to outright disable: [`vars-on-top`](http://eslint.org/docs/rules/vars-on-top), [`one-var`](http://eslint.org/docs/rules/one-var), [`camelcase`](http://eslint.org/docs/rules/camelcase), and [`no-use-before-define`](http://eslint.org/docs/rules/no-use-before-define).

There was also [`comma-dangle`](http://eslint.org/docs/rules/comma-dangle) which is a favourite of mine, but that one works better with Babel transpiling to strip them out, so I left it out for now.

For added benefit, CircleCi has a free tier for open source projects that could be enable for automated linting on commits and pull requests: https://circleci.com/add-projects
(Only the repo admin can enable that though, so I can't turn it on myself)