### PR TITLE
tip.show() accepts absolute positioning, with working html example

### DIFF
--- a/examples/bars-absolute-positioning.html
+++ b/examples/bars-absolute-positioning.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>d3.tip.js - Tooltips for D3</title>
+  <meta charset="utf-8" />
+  <title>Bar Chart</title>
+  <script type="text/javascript" src="../bower_components/d3/d3.js"></script>
+  <script type="text/javascript" src="../index.js"></script>
+  <script type="text/javascript">
+    data = [{"total":225,"days":[12,51,60,26,38,31,7]},{"total":279,"days":[42,33,34,72,61,12,25]},{"total":212,"days":[12,59,24,70,36,5,6]},{"total":335,"days":[17,43,38,58,67,72,40]},{"total":329,"days":[40,53,62,48,38,36,52]},{"total":234,"days":[15,25,41,66,35,37,15]},{"total":175,"days":[2,40,23,40,23,34,13]},{"total":308,"days":[20,22,63,55,51,66,31]},{"total":401,"days":[20,64,42,62,88,79,46]},{"total":214,"days":[24,27,25,48,38,28,24]},{"total":332,"days":[26,43,20,109,74,29,31]},{"total":333,"days":[65,66,62,60,14,43,23]},{"total":437,"days":[33,74,82,70,85,64,29]},{"total":687,"days":[29,82,87,167,156,126,40]},{"total":243,"days":[11,52,44,50,46,30,10]},{"total":360,"days":[16,41,86,62,83,60,12]},{"total":349,"days":[22,55,48,36,88,57,43]},{"total":368,"days":[29,100,68,54,55,46,16]},{"total":377,"days":[3,71,66,57,93,82,5]},{"total":265,"days":[12,61,61,19,44,46,22]},{"total":396,"days":[20,58,70,52,84,93,19]},{"total":467,"days":[25,47,128,93,70,35,69]},{"total":524,"days":[55,79,94,95,122,70,9]},{"total":535,"days":[21,96,95,115,78,89,41]},{"total":333,"days":[20,50,49,52,58,51,53]},{"total":258,"days":[7,23,50,59,46,50,23]},{"total":242,"days":[12,4,54,53,46,33,40]},{"total":335,"days":[1,34,40,75,97,51,37]},{"total":325,"days":[32,57,65,46,60,58,7]},{"total":224,"days":[23,42,43,28,31,27,30]},{"total":317,"days":[20,46,43,46,83,36,43]},{"total":119,"days":[1,10,9,45,30,17,7]},{"total":368,"days":[13,74,77,85,72,40,7]},{"total":271,"days":[10,50,46,61,68,31,5]},{"total":290,"days":[26,48,39,37,68,43,29]},{"total":393,"days":[27,50,133,47,73,37,26]},{"total":316,"days":[2,63,66,47,63,33,42]},{"total":146,"days":[0,32,38,23,45,7,1]},{"total":255,"days":[23,34,72,46,48,24,8]},{"total":196,"days":[9,32,82,18,16,29,10]},{"total":410,"days":[41,52,67,42,49,103,56]},{"total":280,"days":[13,35,40,60,68,53,11]},{"total":432,"days":[45,65,59,55,71,68,69]},{"total":371,"days":[19,104,95,51,66,20,16]},{"total":285,"days":[2,38,50,72,74,47,2]},{"total":350,"days":[47,16,96,93,32,52,14]},{"total":234,"days":[34,68,66,32,5,10,19]},{"total":279,"days":[27,43,64,48,60,25,12]},{"total":391,"days":[40,54,59,68,80,51,39]},{"total":168,"days":[0,44,42,36,30,16,0]},{"total":0,"days":[0,0,0,0,0,0,0]},{"total":14,"days":[6,0,0,0,0,2,6]},{"total":0,"days":[0,0,0,0,0,0,0]}]
+  </script>
+  <link rel="stylesheet" href="example-styles.css">
+  <style type="text/css">
+    body {
+      padding: 40px;
+      font-family: "Helvetica Neue", Helvetica, sans-serif;
+      font-size: 12px;
+      height: 1000px;
+    }
+
+    .d3-tip span {
+      color: #ff00c7;
+    }
+
+    .domain {
+      display: none;
+    }
+
+    .axis line {
+      stroke-width: 1px;
+      stroke: #eee;
+      shape-rendering: crispedges;
+    }
+
+    .axis text {
+      fill: #888;
+    }
+
+    rect {
+      fill: #339cff;
+      fill-opacity: 0.7;
+    }
+
+    rect:hover {
+      fill-opacity: 1;
+    }
+  </style>
+</head>
+<body>
+<div id="graph">
+
+</div>
+<script type="text/javascript">
+  var tip = d3.tip()
+    .attr('class', 'd3-tip')
+    .rootElement(function(){
+      return document.getElementById('graph');
+    })
+    .html(function(d) { return '<span>' + d.total + '</span>' + ' entries' })
+    .offset([-12, 0])
+
+  var w = 800,
+    h = 300,
+    padt = 20, padr = 20, padb = 60, padl = 30,
+    x  = d3.scaleBand().rangeRound([0, w - padl - padr]).padding(0.1),
+    y  = d3.scaleLinear().range([h, 0]),
+    yAxis = d3.axisLeft().scale(y).tickSize(-w + padl + padr),
+    xAxis = d3.axisBottom().scale(x)
+
+  vis = d3.select('#graph')
+    .append('svg')
+    .attr('width', w)
+    .attr('height', h + padt + padb)
+    .append('g')
+    .attr('transform', 'translate(' + padl + ',' + padt + ')')
+
+  var max = d3.max(data, function(d) { return d.total })
+  x.domain(d3.range(data.length))
+  y.domain([0, max])
+
+  vis.call(tip)
+  vis.append("g")
+    .attr("class", "y axis")
+    .call(yAxis)
+
+  vis.append("g")
+    .attr("class", "x axis")
+    .attr('transform', 'translate(0,' + h + ')')
+    .call(xAxis)
+    .selectAll('.x.axis g')
+    .style('display', function (d, i) { return i % 3 != 0  ? 'none' : 'block' })
+
+  var bars = vis.selectAll('g.bar')
+    .data(data)
+    .enter().append('g')
+    .attr('class', 'bar')
+    .attr('transform', function (d, i) { return "translate(" + x(i) + ", 0)" })
+
+  bars.append('rect')
+    .attr('width', function() { return x.rangeBand() })
+    .attr('height', function(d) { return h - y(d.total) })
+    .attr('y', function(d) { return y(d.total) })
+    .on('mouseover', function (d, idx) {
+      // get mouse coordinates and draw new tooltip
+      var absolute = [d3.event.pageY, d3.event.pageX];
+      return tip.show(d, idx, absolute);
+    })
+    .on('mouseout', tip.hide)
+</script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
     /* eslint-disable global-require */
     // CommonJS
     var d3Collection = require('d3-collection'),
-        d3Selection = require('d3-selection')
+      d3Selection = require('d3-selection')
     module.exports = factory(d3Collection, d3Selection)
     /* eslint-enable global-require */
   } else {
@@ -31,13 +31,13 @@
   // Returns a tip
   return function() {
     var direction   = d3TipDirection,
-        offset      = d3TipOffset,
-        html        = d3TipHTML,
-        rootElement = document.body,
-        node        = initNode(),
-        svg         = null,
-        point       = null,
-        target      = null
+      offset      = d3TipOffset,
+      html        = d3TipHTML,
+      rootElement = document.body,
+      node        = initNode(),
+      svg         = null,
+      point       = null,
+      target      = null
 
     function tip(vis) {
       svg = getSVGNode(vis)
@@ -49,29 +49,36 @@
     // Public - show the tooltip on the screen
     //
     // Returns a tip
-    tip.show = function() {
+    tip.show = function(d, idx, absolute) {
       var args = Array.prototype.slice.call(arguments)
       if (args[args.length - 1] instanceof SVGElement) target = args.pop()
 
       var content = html.apply(this, args),
-          poffset = offset.apply(this, args),
-          dir     = direction.apply(this, args),
-          nodel   = getNodeEl(),
-          i       = directions.length,
-          coords,
-          scrollTop  = document.documentElement.scrollTop ||
-            rootElement.scrollTop,
-          scrollLeft = document.documentElement.scrollLeft ||
-            rootElement.scrollLeft
+        poffset = offset.apply(this, args),
+        dir     = direction.apply(this, args),
+        nodel   = getNodeEl(),
+        i       = directions.length,
+        coords,
+        scrollTop  = document.documentElement.scrollTop ||
+          rootElement.scrollTop,
+        scrollLeft = document.documentElement.scrollLeft ||
+          rootElement.scrollLeft
 
       nodel.html(content)
         .style('opacity', 1).style('pointer-events', 'all')
 
       while (i--) nodel.classed(directions[i], false)
       coords = directionCallbacks.get(dir).apply(this)
-      nodel.classed(dir, true)
-        .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
-        .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+      if (!absolute) {
+        nodel.classed(dir, true)
+          .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
+          .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+      }
+      else {
+        nodel.classed(dir, true)
+          .style('top', (absolute[0] + poffset[0]) + scrollTop + 'px')
+          .style('left', (absolute[1] + poffset[1]) + scrollLeft + 'px')
+      }
 
       return tip
     }
@@ -186,16 +193,16 @@
     function d3TipHTML() { return ' ' }
 
     var directionCallbacks = d3Collection.map({
-          n:  directionNorth,
-          s:  directionSouth,
-          e:  directionEast,
-          w:  directionWest,
-          nw: directionNorthWest,
-          ne: directionNorthEast,
-          sw: directionSouthWest,
-          se: directionSouthEast
-        }),
-        directions = directionCallbacks.keys()
+        n:  directionNorth,
+        s:  directionSouth,
+        e:  directionEast,
+        w:  directionWest,
+        nw: directionNorthWest,
+        ne: directionNorthEast,
+        sw: directionSouthWest,
+        se: directionSouthEast
+      }),
+      directions = directionCallbacks.keys()
 
     function directionNorth() {
       var bbox = getScreenBBox()
@@ -310,12 +317,12 @@
       }
 
       var bbox       = {},
-          matrix     = targetel.getScreenCTM(),
-          tbbox      = targetel.getBBox(),
-          width      = tbbox.width,
-          height     = tbbox.height,
-          x          = tbbox.x,
-          y          = tbbox.y
+        matrix     = targetel.getScreenCTM(),
+        tbbox      = targetel.getBBox(),
+        width      = tbbox.width,
+        height     = tbbox.height,
+        x          = tbbox.x,
+        y          = tbbox.y
 
       point.x = x
       point.y = y


### PR DESCRIPTION
I added the possibility of passing absolute positioning coordinates to d3-tip. This enables you to draw the tip dynamically, with respect to the mouse pointer, or statically, always passing the same exact coordinates.

I also made an example page based on bars.html to show how it works:
tip.show(d, idx, absolute)
where absolute is an array of absolute coordinates [Y, X]

A PR with similar functionality was proposed in https://github.com/Caged/d3-tip/pull/114
