### PR TITLE
Import d3 instead of d3-selection and d3-collection, and fix whild condition in getScreenBBox

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,10 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module with d3 as a dependency.
     define([
-      'd3-collection',
-      'd3-selection'
-    ], factory)
+      'd3'
+    ], function(d3) {
+        return factory(d3, d3)
+    })
   } else if (typeof module === 'object' && module.exports) {
     /* eslint-disable global-require */
     // CommonJS

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@
     function getScreenBBox() {
       var targetel   = target || d3Selection.event.target
 
-      while (targetel.getScreenCTM == null && targetel.parentNode == null) {
+      while (targetel.getScreenCTM == null && targetel.parentNode != null) {
         targetel = targetel.parentNode
       }
 


### PR DESCRIPTION
I usually import d3, not its sub-libraries separately in requirejs.
If d3-collection and d3-selection are loaded separately from existing d3, it cannot catch events, so d3Selection.event will be empty in getScreenBBox function, and I actually had that error.
Therefore, I replaced d3-collection and d3-selection with d3, and The error was fixed.

Also, while condition in getScreenBBox was not correct. That condition will make targetel null and cause error of 'targetel.getScreenCTM is not a function' what I had.
After fixing that condition, the error was fixed.