### PR TITLE
Adds try/catch to workaround Firefox v.57 getBBox exception NS_ERROR_NOT_IMPLEMENTED

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,6 +305,19 @@
     function getScreenBBox() {
       var targetel   = target || d3Selection.event.target
 
+      function tryBBox(){ // workaround for bug in FF where `typeof targetel.getBBox` returns 'function'
+                          // but calling `targetel.getBBox()` results in an exception "NS_ERROR_NOT_IMPLEMENTED"
+                          // use case was where the `getBBox` failed on a <tspan> but succeeded on its parentNode <text>
+                          
+        try {
+          targetel.getBBox();
+        }
+        catch (err) {
+          targetel = targetel.parentNode;
+          tryBBox();
+        }
+      }
+
       while (targetel.getScreenCTM == null && targetel.parentNode == null) {
         targetel = targetel.parentNode
       }


### PR DESCRIPTION
The `getBBox` method fails in Firefox v.57 on <tspan> elements and perhaps on other child-only SVGElements. `typeof targetel.getBBox` returns 'function' but calling that function results in an exception "NS_ERROR_NOT_IMPLEMENTED".

That results in the tooltip being placed at the top left of the body (0,0) when triggered by an element for which `getBBox` was not implemented.

![image](https://user-images.githubusercontent.com/13643664/34523755-d11c53ce-f066-11e7-8d48-8899751743a9.png)

This PR adds a try/catch that changes `targetel` to `targetel.parentNode` if `targetel.getBBox()` fails.