### PR TITLE
Fix while loop condition in getScreenBox

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@
     function getScreenBBox() {
       var targetel   = target || d3Selection.event.target
 
-      while (targetel.getScreenCTM == null && targetel.parentNode == null) {
+      while (targetel.getScreenCTM == null && targetel.parentNode != null) {
         targetel = targetel.parentNode
       }
 


### PR DESCRIPTION
If the code ever enters the current while loop, an error is guaranteed to be thrown. Consider that if the loop is entered then targetel.parentNode == null (so is either undefined or null), then targetel will be reassigned to targetel.parentNode (again this will either be null or undefined) and then immediately attempt to check whether targetel.getScreenCTM == null and throw because you cannot read getScreenCTM of null or undefined.