### PR TITLE
Add workaround for getScreenBBox() for IE11 and 'use' tag target elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,8 +276,13 @@
     function getScreenBBox() {
       var targetel   = target || d3.event.target;
 
-      while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
+      while ('function' !== typeof targetel.getScreenCTM  && 'undefined' !== typeof targetel.parentNode) {
+        var isIE11 = 'undefined' !== typeof targetel.correspondingElement && 'function' === typeof targetel.correspondingElement.getScreenCTM;
+        if (!isIE11) {
           targetel = targetel.parentNode;
+        } else {
+          targetel = targetel.correspondingElement;
+        }
       }
 
       var bbox       = {},

--- a/index.js
+++ b/index.js
@@ -277,11 +277,13 @@
       var targetel   = target || d3.event.target;
 
       while ('function' !== typeof targetel.getScreenCTM  && 'undefined' !== typeof targetel.parentNode) {
-        var isIE11 = 'undefined' !== typeof targetel.correspondingElement && 'function' === typeof targetel.correspondingElement.getScreenCTM;
+        var isIE11UseElement = 'undefined' !== typeof targetel.correspondingUseElement;
+        var isIE11OtherElement = 'undefined' !== typeof targetel.correspondingElement && 'function' === typeof targetel.correspondingElement.getScreenCTM;
+        var isIE11 = isIE11UseElement || isIE11OtherElement;
         if (!isIE11) {
           targetel = targetel.parentNode;
         } else {
-          targetel = targetel.correspondingElement;
+          targetel = isIE11UseElement ? targetel.correspondingUseElement : correspondingElement;
         }
       }
 


### PR DESCRIPTION
IE11 browser does not provide the function getScreenBBox() for objects resulting from a 'use' tag. For those targetel objects getScreenBBox() threw an exception "Object doesn't support property or method 'getScreenCTM'" because IE11 uses the correspondingElement property to provide the getScreenCTM() function.

Additionally the while condition for targetel.parentNode has been negated because previously the while loop has only been entered when typeof targetel.parentNode == null which seems to make no sense.