### PR TITLE
Keep southward tooltips on screen

### DIFF
--- a/examples/example-styles.css
+++ b/examples/example-styles.css
@@ -53,3 +53,20 @@
   top: 50%;
   left: 100%;
 }
+
+/* Southward tooltips that extend eastward */
+.d3-tip.sse:after {
+  content: "\25B2";
+  margin: 0 0 1px 0;
+  top: -8px;
+  left: 11px;
+}
+
+/* Southward tooltips that extend westward */
+.d3-tip.ssw:after {
+  content: "\25B2";
+  margin: 0 0 1px 0;
+  top: -8px;
+  right: 11px;
+  text-align: right;
+}

--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ export default function() {
         nodel   = getNodeEl(),
         i       = directions.length,
         coords,
+        left,
+        bbox,
         scrollTop  = document.documentElement.scrollTop ||
       rootElement.scrollTop,
         scrollLeft = document.documentElement.scrollLeft ||
@@ -48,11 +50,44 @@ export default function() {
     nodel.html(content)
       .style('opacity', 1).style('pointer-events', 'all')
 
+    // un-constrain tooltip and calculate natural left coordinate
+    nodel.style('left', '0')
+      .style('width', '');
+    coords = directionCallbacks.get(dir).apply(this);
+    left = (coords.left + poffset[1]) + scrollLeft;
+
+    // adjust left coordinate as needed
+    if (dir === 's') {
+      if (left < 0) {
+        dir = 'sse';
+        bbox = getScreenBBox(this);
+        if (bbox.e.x - bbox.w.x > 16) {
+          left = bbox.w.x - 8;
+        } else {
+          left = bbox.s.x - 16;
+        }
+      } else if (left + node.clientWidth > window.innerWidth) {
+        dir = 'ssw';
+        bbox = getScreenBBox(this);
+        if (bbox.e.x - bbox.w.x > 16) {
+          left = bbox.e.x + 8 - node.clientWidth;
+        } else {
+          left = bbox.s.x + 16 - node.clientWidth;
+        }
+        if (left < 0) {
+          // constrain width so it will wrap
+          nodel.style('width', node.clientWidth + left + 'px');
+          left = 0;
+        }
+      }
+    }
+
     while (i--) nodel.classed(directions[i], false)
-    coords = directionCallbacks.get(dir).apply(this)
+    nodel.classed('sse', false)
+        .classed('ssw', false);
     nodel.classed(dir, true)
       .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
-      .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+      .style('left', left + 'px')
 
     return tip
   }


### PR DESCRIPTION
Hi!

Tooltips going off screen is a particular problem for flame graphs which tend to have long tooltips (see https://github.com/spiermar/d3-flame-graph/issues/109 and https://github.com/glowroot/glowroot/issues/457).

I started out with another option for keeping tooltips on screen (based on #198), but I think that keeping the tooltips always south of the frame (instead of jumping to the east or west of the frame) is much nicer for flame graphs.

You can see the patched version in action at https://demo.glowroot.org/transaction/thread-flame-graph?transaction-type=Web

Please let me know if this is acceptable, or if you would like to see any changes I'd be happy to re-work it.

Thanks,
Trask