### PR TITLE
Add classed functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,22 @@ export default function() {
     return tip
   }
 
+  // Public: Proxy classed calls to the d3 tip container.  Sets or gets class value.
+  //
+  // n - name of the class
+  // v - value indicating whether to class or unclass
+  //
+  // Returns tip or class value
+  tip.classed = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().classed(n)
+    }
+
+    var args =  Array.prototype.slice.call(arguments)
+    selection.prototype.classed.apply(getNodeEl(), args)
+    return tip
+  }
+
   // Public: Proxy style calls to the d3 tip container.
   // Sets or gets a style value.
   //

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ export default function() {
     return tip
   }
 
-  function d3TipDirection() { return 'n' }
+  function d3TipDirection() { return 's' }
   function d3TipOffset() { return [0, 0] }
   function d3TipHTML() { return ' ' }
 


### PR DESCRIPTION
Use case: in case people want to style the tooltip along with its 'after' pseudo element. AFAIK, there is no way to use tip.style to style pseudo elements. Let me know if there is.