### PR TITLE
Tooltip positioning with specified rootElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export default function() {
   var direction   = d3TipDirection,
       offset      = d3TipOffset,
       html        = d3TipHTML,
-      rootElement = () => document.body,
+      rootElement = function() { return document.body },
       node        = initNode(),
       svg         = null,
       point       = null,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ export default function() {
   var direction   = d3TipDirection,
       offset      = d3TipOffset,
       html        = d3TipHTML,
-      rootElement = document.body,
+      rootElement = () => document.body,
       node        = initNode(),
       svg         = null,
       point       = null,
@@ -24,7 +24,7 @@ export default function() {
     svg = getSVGNode(vis)
     if (!svg) return
     point = svg.createSVGPoint()
-    rootElement.appendChild(node)
+    rootElement().appendChild(node)
   }
 
   // Public - show the tooltip on the screen
@@ -41,9 +41,9 @@ export default function() {
         i       = directions.length,
         coords,
         scrollTop  = document.documentElement.scrollTop ||
-      rootElement.scrollTop,
+      rootElement().scrollTop,
         scrollLeft = document.documentElement.scrollLeft ||
-      rootElement.scrollLeft
+      rootElement().scrollLeft
 
     nodel.html(content)
       .style('opacity', 1).style('pointer-events', 'all')
@@ -265,7 +265,7 @@ export default function() {
     if (node == null) {
       node = initNode()
       // re-add node to DOM
-      rootElement.appendChild(node)
+      rootElement().appendChild(node)
     }
     return select(node)
   }

--- a/index.js
+++ b/index.js
@@ -41,9 +41,10 @@ export default function() {
         i       = directions.length,
         coords,
         rect = nodel.node().offsetParent.getBoundingClientRect(),
-        viewportOffsetTop  = rect.top,
-        viewportOffsetLeft = rect.left,
-        scrollOffsets = getNetScrollOffset(nodel.node())
+        scrollOffsets = getNetScrollOffset(nodel.node()),
+        viewportOffsetTop  = rect.top - scrollOffsets.scrollTop,
+        viewportOffsetLeft = rect.left - scrollOffsets.scrollLeft
+
 
     if (nodel.node().offsetParent === document.body) {
       var bodyStyle = window.getComputedStyle(document.body)
@@ -57,8 +58,8 @@ export default function() {
     while (i--) nodel.classed(directions[i], false)
     coords = directionCallbacks.get(dir).apply(this)
     nodel.classed(dir, true)
-      .style('top', (coords.top + poffset[0]) - viewportOffsetTop + scrollOffsets.scrollTop + 'px')
-      .style('left', (coords.left + poffset[1]) - viewportOffsetLeft + scrollOffsets.scrollLeft + 'px')
+      .style('top', (coords.top + poffset[0]) - viewportOffsetTop + 'px')
+      .style('left', (coords.left + poffset[1]) - viewportOffsetLeft + 'px')
 
     return tip
   }

--- a/index.js
+++ b/index.js
@@ -40,10 +40,16 @@ export default function() {
         nodel   = getNodeEl(),
         i       = directions.length,
         coords,
-        scrollTop  = document.documentElement.scrollTop ||
-      rootElement().scrollTop,
-        scrollLeft = document.documentElement.scrollLeft ||
-      rootElement().scrollLeft
+        rect = nodel.node().offsetParent.getBoundingClientRect(),
+        viewportOffsetTop  = rect.top,
+        viewportOffsetLeft = rect.left,
+        scrollOffsets = getNetScrollOffset(nodel.node())
+
+    if (nodel.node().offsetParent === document.body) {
+      var bodyStyle = window.getComputedStyle(document.body)
+      viewportOffsetTop -= parseInt(bodyStyle.marginTop, 10)
+      viewportOffsetLeft -= parseInt(bodyStyle.marginLeft, 10)
+    }
 
     nodel.html(content)
       .style('opacity', 1).style('pointer-events', 'all')
@@ -51,8 +57,8 @@ export default function() {
     while (i--) nodel.classed(directions[i], false)
     coords = directionCallbacks.get(dir).apply(this)
     nodel.classed(dir, true)
-      .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
-      .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+      .style('top', (coords.top + poffset[0]) - viewportOffsetTop + scrollOffsets.scrollTop + 'px')
+      .style('left', (coords.left + poffset[1]) - viewportOffsetLeft + scrollOffsets.scrollLeft + 'px')
 
     return tip
   }
@@ -328,4 +334,18 @@ export default function() {
   }
 
   return tip
+}
+
+function getNetScrollOffset(el) {
+  var targetEl = el
+  var stopper = el.offsetParent.parentNode
+  var offsets = {
+    scrollTop: 0, scrollLeft: 0
+  }
+  while (targetEl.parentNode && targetEl.parentNode !== stopper) {
+    targetEl = targetEl.parentNode
+    offsets.scrollTop += targetEl.scrollTop
+    offsets.scrollLeft += targetEl.scrollLeft
+  }
+  return offsets
 }


### PR DESCRIPTION
Thanks for this library. This PR resolves issues with using the rootElement method to specify a root for the tooltip div that is not statically positioned at the document root. 

1. Resolve errors that arise when using rootElement by treating the variable consistently as a function that returns a node
2. Account for positioning, scrolling, and document margins when calculating tooltip position. 

This covers all the following positioning cases:
1. Tooltip parent is static position or is the document root
2. Tooltip parent has position adjustments and is not in the same layout tree as the chart
3. Tooltip parent has position adjustments and is in the same layout tree as the chart
3. Chart is inside of a scrolled parent in any of the above scenarios